### PR TITLE
Add Windows support for GLFW and ImGui

### DIFF
--- a/modules/glfw/3.3.9/patches/add_build_file.patch
+++ b/modules/glfw/3.3.9/patches/add_build_file.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ BUILD.bazel
-@@ -0,0 +1,117 @@
+@@ -0,0 +1,137 @@
 +cc_library(
 +    name = "glfw-headers",
 +    hdrs = [
@@ -75,6 +75,22 @@
 +    "src/x11_window.c",
 +]
 +
++WINDOWS_HDRS = [
++    "src/win32_joystick.h",
++    "src/win32_platform.h",
++    "src/wgl_context.h",
++]
++
++WINDOWS_SRCS = [
++    "src/win32_init.c",
++    "src/win32_joystick.c",
++    "src/win32_monitor.c",
++    "src/win32_time.c",
++    "src/win32_thread.c",
++    "src/win32_window.c",
++    "src/wgl_context.c",
++]
++
 +objc_library(
 +    name = "glfw-cocoa",
 +    srcs = COMMON_SRCS + DARWIN_SRCS,
@@ -105,6 +121,22 @@
 +)
 +
 +cc_library(
++    name = "glfw-win32",
++    srcs = COMMON_SRCS + WINDOWS_SRCS,
++    hdrs = COMMON_HDRS + WINDOWS_HDRS,
++    defines = [
++        "_GLFW_WIN32",
++        "UNICODE",
++        "_UNICODE",
++    ],
++    linkopts = select({
++        "@platforms//os:windows": ["-DEFAULTLIB:gdi32"],
++        "//conditions:default": [],
++    }),
++    visibility = ["//visibility:private"],
++)
++
++cc_library(
 +    name = "glfw",
 +    visibility = ["//visibility:public"],
 +    deps = select({
@@ -115,6 +147,10 @@
 +        "@bazel_tools//src/conditions:darwin": [
 +            ":glfw-cocoa",
 +            ":glfw-headers",
++        ],
++        "@bazel_tools//src/conditions:windows": [
++            ":glfw-headers",
++            ":glfw-win32",
 +        ],
 +    }),
 +)

--- a/modules/glfw/3.3.9/presubmit.yml
+++ b/modules/glfw/3.3.9/presubmit.yml
@@ -4,6 +4,12 @@ matrix:
   bazel: [7.x, 8.x] 
 
 tasks:
+  verify_windows_targets:
+    name: Verify windows build and test targets
+    platform: windows
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@glfw//:glfw'
   verify_linux_targets:
     name: Verify linux build and test targets
     platform: ${{ linux_platform }}

--- a/modules/imgui/1.91.8/overlay/backends/BUILD.bazel
+++ b/modules/imgui/1.91.8/overlay/backends/BUILD.bazel
@@ -14,13 +14,8 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
-    # TODO: Remove this section after adding Windows support to @glfw:
-    # https://registry.bazel.build/modules/glfw
-    target_compatible_with = select({
-        "@platforms//os:osx": [],
-        "@platforms//os:linux": [],
-        "//conditions:default": ["@platforms//:incompatible"],
-    }),
+    # Windows support added to @glfw; no platform restrictions needed
+
     deps = [
         "//:imgui",
         "@glfw",


### PR DESCRIPTION
## Summary
- add Windows build sources to glfw build patch
- remove platform restrictions in imgui glfw backend
- verify Windows builds in glfw presubmit

## Testing
- `bazel run -- //tools:bcr_validation --check=glfw@3.3.9 --check=imgui@1.91.8`

------
https://chatgpt.com/codex/tasks/task_e_6840a608494c832c90db88d0998679dc